### PR TITLE
Fix #32: add coverage configuration file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    if __name__ == '__main__':


### PR DESCRIPTION
Added a `.coveragerc`.  Now it just skips the lines of the block `if __name__ == '__main__':`