### PR TITLE
Fix #45: call coveralls from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,11 +36,14 @@ deps = sphinx
 commands = sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc doc/_build/linkcheck
 
 [testenv:coverage-report]
-deps = coverage
+deps =
+    coverage
+    coveralls
 skip_install = true
 commands =
     coverage report
     coverage html
+    - coveralls
 
 [testenv:codecov]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
I need to merge this pull request without testing the changes, because coveralls.io make the repos only from the master branch.