### PR TITLE
Fix #81

### DIFF
--- a/simulators/utils.py
+++ b/simulators/utils.py
@@ -1,4 +1,5 @@
 import math
+import struct
 from datetime import datetime
 
 
@@ -109,10 +110,32 @@ def bytes_to_int(byte_string):
     return twos_to_int(binary_string)
 
 
+def double_to_binary(num):
+    """Return the binary representation of a double-precision floating-point
+    number (IEEE 754 standard). A format description can be found here:
+    https://en.wikipedia.org/wiki/Double-precision_floating-point_format.
+
+    >>> double_to_binary(1)
+    '0011111111110000000000000000000000000000000000000000000000000000'
+
+    >>> double_to_binary(0.56734)
+    '0011111111100010001001111010011000110111001101101100110111110010'
+
+    >>> double_to_binary(619.34000405413)
+    '0100000010000011010110101011100001010100000010111010011111110111'
+    """
+
+    return ''.join(
+        bin(ord(c)).replace('0b', '').rjust(8, '0')
+        for c in struct.pack('!d', num)
+    )
+
+
 def mjd():
     """Return the modified julian date.
     For more informations about modified julian date check the following link:
     https://bowie.gsfc.nasa.gov/time/"""
+
     utcnow = datetime.utcnow()
 
     year = utcnow.year

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,7 +66,7 @@ class TestServer(unittest.TestCase):
         self.assertNotEqual(byte_string, expected_byte_string)
 
     def test_bytes_to_int_correct(self):
-        """Convert a string of bytes into an integer (like C atoi function)"""
+        """Convert a string of bytes into an integer (like C atoi function)."""
         byte_string = b'\x00\x00\xFA\xFF'
         result = utils.bytes_to_int(byte_string)
         expected_result = 64255
@@ -76,6 +76,23 @@ class TestServer(unittest.TestCase):
         byte_string = b'\x00\x00\xFA\xFF'
         result = utils.bytes_to_int(byte_string)
         expected_result = -1281
+        self.assertNotEqual(result, expected_result)
+
+    def test_double_to_binary(self):
+        """Convert a double to its binary representation."""
+        number = 3.14159265358979323846264338327950288419716939937510582097494
+        result = utils.double_to_binary(number)
+        expected_result = (
+            '0100000000001001001000011111101101010100010001000010110100011000'
+        )
+        self.assertEqual(result, expected_result)
+
+    def test_double_to_binary_wrong(self):
+        number = 3.14159265358979323846264338327950288419716939937510582097494
+        result = utils.double_to_binary(number)
+        expected_result = (
+            '0100000000001001001010011111101101010100010001000010110100011000'
+        )
         self.assertNotEqual(result, expected_result)
 
 if __name__ == '__main__':


### PR DESCRIPTION
utils.double_to_binary() converts a floating-point number into its binary representation following the [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754).