### PR TITLE
Fix issue 96, expanded functionality of double_to_binary

### DIFF
--- a/simulators/utils.py
+++ b/simulators/utils.py
@@ -110,25 +110,38 @@ def bytes_to_int(byte_string):
     return twos_to_int(binary_string)
 
 
-def double_to_binary(num):
-    """Return the binary representation of a double-precision floating-point
-    number (IEEE 754 standard). A format description can be found here:
+def real_to_binary(num, precision=1):
+    """Return the binary representation of a floating-point number
+    (IEEE 754 standard).
+    A single-precision format description can be found here:
+    https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+    A double-precision format description can be found here:
     https://en.wikipedia.org/wiki/Double-precision_floating-point_format.
 
-    >>> double_to_binary(1)
-    '0011111111110000000000000000000000000000000000000000000000000000'
+    >>> real_to_binary(619.34000405413)
+    '01000100000110101101010111000011'
 
-    >>> double_to_binary(0.56734)
-    '0011111111100010001001111010011000110111001101101100110111110010'
-
-    >>> double_to_binary(619.34000405413)
+    >>> real_to_binary(619.34000405413, 2)
     '0100000010000011010110101011100001010100000010111010011111110111'
-    """
 
-    return ''.join(
-        bin(ord(c)).replace('0b', '').rjust(8, '0')
-        for c in struct.pack('!d', num)
-    )
+    >>> real_to_binary(0.56734, 1)
+    '00111111000100010011110100110010'
+    """
+    if precision == 1:
+        return ''.join(
+            bin(ord(c)).replace('0b', '').rjust(8, '0')
+            for c in struct.pack('!f', num)
+        )
+    elif precision == 2:
+        return ''.join(
+            bin(ord(c)).replace('0b', '').rjust(8, '0')
+            for c in struct.pack('!d', num)
+        )
+    else:
+        raise ValueError(
+            "Unknown precision %d."
+            % (precision)
+        )
 
 
 def mjd():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,22 +78,36 @@ class TestServer(unittest.TestCase):
         expected_result = -1281
         self.assertNotEqual(result, expected_result)
 
-    def test_double_to_binary(self):
-        """Convert a double to its binary representation."""
+    def test_real_to_binary_single_precision(self):
+        """Convert a real number to its binary representation."""
         number = 3.14159265358979323846264338327950288419716939937510582097494
-        result = utils.double_to_binary(number)
+        result = utils.real_to_binary(number)
+        expected_result = (
+            '01000000010010010000111111011011'
+        )
+        self.assertEqual(result, expected_result)
+
+    def test_real_to_binary_double_precision(self):
+        """Convert a real number to its binary representation."""
+        number = 3.14159265358979323846264338327950288419716939937510582097494
+        result = utils.real_to_binary(number, 2)
         expected_result = (
             '0100000000001001001000011111101101010100010001000010110100011000'
         )
         self.assertEqual(result, expected_result)
 
-    def test_double_to_binary_wrong(self):
+    def test_real_to_binary_wrong(self):
         number = 3.14159265358979323846264338327950288419716939937510582097494
-        result = utils.double_to_binary(number)
+        result = utils.real_to_binary(number)
         expected_result = (
             '0100000000001001001010011111101101010100010001000010110100011000'
         )
         self.assertNotEqual(result, expected_result)
+
+    def test_real_to_binary_unknown_precision(self):
+        number = 3.14159265358979323846264338327950288419716939937510582097494
+        with self.assertRaises(ValueError):
+            result = utils.real_to_binary(number, 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,7 +107,7 @@ class TestServer(unittest.TestCase):
     def test_real_to_binary_unknown_precision(self):
         number = 3.14159265358979323846264338327950288419716939937510582097494
         with self.assertRaises(ValueError):
-            result = utils.real_to_binary(number, 3)
+            utils.real_to_binary(number, 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now the method is called real_to_binary and can transform both single and double precision numbers.