### PR TITLE
Fix #155, fixed USDs startup proecdure and soft reset command.

### DIFF
--- a/simulators/active_surface/__init__.py
+++ b/simulators/active_surface/__init__.py
@@ -12,17 +12,13 @@ from simulators.active_surface.usd import USD
 servers = []
 for line in range(96):  # 96 servers
     l_address = ('127.0.0.1', 11000 + line)
-    # We set as extra arg the default driver_reset_delay (100ms)
-    servers.append((l_address, (), (100)))
+    servers.append((l_address, (), ()))
 
 
 class System(ListeningSystem):
     """The active surface is composed of 8 sectors, and each sector
     has 12 lines of actuators.  The antenna control software must open
     one TCP socket for each line.  This class represents a line.
-
-    :param driver_reset_delay: a parameter that is passed down to all of
-        the children USDs. Refer to USD class to further documentation.
     """
 
     functions = {
@@ -59,9 +55,9 @@ class System(ListeningSystem):
     delay_step = 0.000512  # 512 microseconds
     slope_time = 10  # msec
 
-    def __init__(self, driver_reset_delay=0):
+    def __init__(self):
         self._set_default()
-        self.drivers = [USD(driver_reset_delay) for _ in range(32)]
+        self.drivers = [USD() for _ in range(32)]
 
     def _set_default(self):
         """This method reset the received command string to its default value.

--- a/simulators/active_surface/usd.py
+++ b/simulators/active_surface/usd.py
@@ -6,12 +6,9 @@ from threading import Thread
 class USD(object):
     """This class represents a single USD actuator driver. It is completely
     handled by the active surface System class.
-
-    :param driver_reset_delay: this argument represents the time in which the
-        driver performs its reset procedure. It defaults to 0 to speed up the
-        testing process.
     """
 
+    driver_reset_delay = 0.1  # 100 milliseconds
     standby_delay_step = 0.004096  # 4096 microseconds
 
     # Resolution denominator, i.e.:
@@ -43,13 +40,10 @@ class USD(object):
         1: 19200
     }
 
-    def __init__(self, driver_reset_delay=0):
-        self.driver_reset_delay = driver_reset_delay  # Actual delay: 100ms
+    def __init__(self):
         self._set_default()
 
     def _set_default(self):
-        t0 = time.time()
-
         self.reference_position = 0
         self.current_position = 0
         self.position_queue = Queue()
@@ -92,12 +86,13 @@ class USD(object):
         self.move_thread = None
         self.move_to_thread = None
 
-        elapsed_time = time.time() - t0
-
-        time.sleep(max(self.driver_reset_delay - elapsed_time, 0))
-
     def soft_reset(self):
+        t0 = time.time()
+
         self._set_default()
+
+        elapsed_time = time.time() - t0
+        time.sleep(max(self.driver_reset_delay - elapsed_time, 0))
 
     def soft_trigger(self):
         if self.ready is True:


### PR DESCRIPTION
Now at bootstrap, the USDs do not perform the soft reset procedure, therefore they do not take 100ms to boot. They sleep 100ms only when the soft reset method is called.