### PR TITLE
Fix #184, set the ACU default sampling time to 100ms

### DIFF
--- a/simulators/acu/__init__.py
+++ b/simulators/acu/__init__.py
@@ -47,7 +47,7 @@ class System(ListeningSystem, SendingSystem):
         4: '_program_track_parameter_command',
     }
 
-    def __init__(self, sampling_time=0.2):
+    def __init__(self, sampling_time=0.1):
         self._set_default()
         self.sampling_time = sampling_time
         self.cmd_counter = None

--- a/simulators/acu/__init__.py
+++ b/simulators/acu/__init__.py
@@ -47,7 +47,9 @@ class System(ListeningSystem, SendingSystem):
         4: '_program_track_parameter_command',
     }
 
-    def __init__(self, sampling_time=0.1):
+    default_sampling_time = 0.1
+
+    def __init__(self, sampling_time=default_sampling_time):
         self._set_default()
         self.sampling_time = sampling_time
         self.cmd_counter = None

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -2168,7 +2168,7 @@ class TestACUSimulator(unittest.TestCase):
             self.assertEqual(status[-4:], self.end_flag)
             self.assertNotEqual(prev, status)
             prev = status
-            time.sleep(0.1)
+            time.sleep(acu.System.default_sampling_time)
         s.close()
 
     def test_multiple_clients(self):

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -2168,7 +2168,7 @@ class TestACUSimulator(unittest.TestCase):
             self.assertEqual(status[-4:], self.end_flag)
             self.assertNotEqual(prev, status)
             prev = status
-            time.sleep(0.2)
+            time.sleep(0.1)
         s.close()
 
     def test_multiple_clients(self):


### PR DESCRIPTION
This change is consistent to the actual sampling time of the SRT's ACU.