### PR TITLE
Fix #182, fixed the stow/unstow behavior

### DIFF
--- a/simulators/acu/axis_status.py
+++ b/simulators/acu/axis_status.py
@@ -1401,9 +1401,11 @@ class MasterAxisStatus(SimpleAxisStatus):
         if self.stowed:
             self.stow_pin_out = self.stow_pin_selection
             self.stow_pin_in = [False for __ in range(16)]
+            self.Stowpins_Extracted = True
         else:
             self.stow_pin_out = [False for __ in range(16)]
             self.stow_pin_in = self.stow_pin_selection
+            self.Stowpins_Extracted = False
 
     def _calc_position(self, delta_time, desired_pos, desired_rate):
         """This method calculates the current position of the axis
@@ -1811,6 +1813,7 @@ class MasterAxisStatus(SimpleAxisStatus):
         if self.stow_pos:
             self.stow_pin_out = self.stow_pin_selection
             self.stow_pin_in = [False for __ in range(16)]
+            self.Stowpins_Extracted = True
             self.stowed = True
 
         self.executed_mode_command_counter = counter
@@ -1826,6 +1829,7 @@ class MasterAxisStatus(SimpleAxisStatus):
         if self.stow_pos:
             self.stow_pin_out = [False for __ in range(16)]
             self.stow_pin_in = self.stow_pin_selection
+            self.Stowpins_Extracted = False
             self.stowed = False
 
         self.executed_mode_command_counter = counter
@@ -1850,6 +1854,7 @@ class MasterAxisStatus(SimpleAxisStatus):
                 return
             self.stow_pin_out = self.stow_pin_selection
             self.stow_pin_in = [False for __ in range(16)]
+            self.Stowpins_Extracted = True
             self.stowed = True
 
         self.executed_mode_command_counter = counter


### PR DESCRIPTION
The stow/unstow procedure was not executed by DISCOS because of the wrong value of the `Stowpins_Extracted` warning status.