### PR TITLE
Fix #208, fix #209, see changelog below.

### DIFF
--- a/simulators/acu/__init__.py
+++ b/simulators/acu/__init__.py
@@ -143,7 +143,7 @@ class System(ListeningSystem, SendingSystem):
                 command_thread.join()
             except Empty:
                 break
-        return '$server_shutdown!'
+        return '$server_shutdown%'
 
     def _set_default(self):
         """This method resets the received command string to its default value.

--- a/simulators/common.py
+++ b/simulators/common.py
@@ -2,36 +2,54 @@ import abc
 
 
 class BaseSystem(object):
+    """This class, as its name says, it is the `System` class from which every
+    other `System` class is inherited. If a custom command that can be useful
+    for every kind of simulator has to be implemented, this class is the right
+    place."""
 
     __metaclass__ = abc.ABCMeta
 
     @staticmethod
     def system_stop():
-        """This method sends back to the server the message `$server_shutdown!`
+        """This method sends back to the server the message `$server_shutdown%`
         ordering it to stop accepting requests and to shut down."""
-        return '$server_shutdown!'
+        return '$server_shutdown%'
 
 
 class ListeningSystem(BaseSystem):
+    """This class implements a server that wait for its client(s) to send a
+    command, it can then answer back when required. Unlike the `SendingSystem`
+    described below, it does not start any communication with any client right
+    after the connection is established."""
 
     @abc.abstractmethod
     def parse(self, byte):
-        """This method takes a byte (single character string) and returns:
-        False when the given byte is not the header, but the header is
-        expected, True when the given byte is the header or a following
-        expected byte, the response (the string to be sent back to the client)
-        when the message is completed.
-        The method eventually raises a ValueError in one of the following
-        cases: the declared length of the message exceeds the maximum expected
-        length, the sent message carries a wrong checksum, the client asks to
-        execute an unknown command.
-        Additional information here:
+        """This method receives and parses the command to be sent to the
+        System. Additional information here:
         https://github.com/discos/simulators/issues/1
 
-        :param byte: the received message byte."""
+        :param byte: the received message byte.
+        :type byte: byte
+        :return: False when the given byte is not the header, but the header is
+            expected. True when the given byte is the header or a following
+            expected byte. The response (the string to be sent back to the
+            client) when the message is completed.
+        :rtype: boolean, string
+        :raise ValueError: when the declared length of the message exceeds the
+            maximum expected length, when the sent message carries a wrong
+            checksum or when the client asks to execute an unknown command."""
 
 
 class SendingSystem(BaseSystem):
+    """This class implements a server that, as soon as a client(s) opens a
+    connection, it starts periodically sending to the said client(s)
+    information regarding the status of the system. The time period is the one
+    defined as `sampling_time` variable, which defaults to 10ms and can be
+    overridden. The class also accepts simulator-related custom commands, but
+    no regular commands are accepted (they are ignored and immediately
+    discarded)."""
+
+    sampling_time = 0.01  # 10ms
 
     @abc.abstractmethod
     def subscribe(self, q):
@@ -43,7 +61,8 @@ class SendingSystem(BaseSystem):
         https://github.com/discos/simulators/issues/175
 
         :param q: the queue object in which the System will put the last status
-            message to be sent to the client."""
+            message to be sent to the client.
+        :type q: Queue"""
 
     @abc.abstractmethod
     def unsubscribe(self, q):
@@ -55,7 +74,8 @@ class SendingSystem(BaseSystem):
         https://github.com/discos/simulators/issues/175
 
         :param q: the queue object that contains the last status message to
-            send to the connected client."""
+            send to the connected client.
+        :type q: Queue"""
 
 
 class MultiTypeSystem(object):

--- a/simulators/common.py
+++ b/simulators/common.py
@@ -17,7 +17,7 @@ class BaseSystem(object):
 
 
 class ListeningSystem(BaseSystem):
-    """This class implements a server that wait for its client(s) to send a
+    """This class implements a server that waits for its client(s) to send a
     command, it can then answer back when required. Unlike the `SendingSystem`
     described below, it does not start any communication with any client right
     after the connection is established."""
@@ -41,13 +41,12 @@ class ListeningSystem(BaseSystem):
 
 
 class SendingSystem(BaseSystem):
-    """This class implements a server that, as soon as a client(s) opens a
-    connection, it starts periodically sending to the said client(s)
-    information regarding the status of the system. The time period is the one
-    defined as `sampling_time` variable, which defaults to 10ms and can be
-    overridden. The class also accepts simulator-related custom commands, but
-    no regular commands are accepted (they are ignored and immediately
-    discarded)."""
+    """This class implements a server that periodically sends some information
+    data regarding the status of the system to every connected client.
+    The time period is the one defined as `sampling_time` variable, which
+    defaults to 10ms and can be overridden. The class also accepts
+    simulator-related custom commands, but no regular commands are accepted
+    (they are ignored and immediately discarded)."""
 
     sampling_time = 0.01  # 10ms
 

--- a/simulators/server.py
+++ b/simulators/server.py
@@ -73,11 +73,11 @@ class ListenHandler(BaseHandler):
     def handle(self):
         """This method gets called right after the `setup` method ends its
         execution. It handles incoming messages, whether they are received via
-        a TCP or a UDP socket. It pass down the the `System` class the received
+        a TCP or a UDP socket. It passes down the `System` class the received
         messages one byte at a time in order for the `System.parse()` method to
         work properly. It then returns the `System` response when necessary.
-        It also constantly listens for custom commands that does not belong to
-        a specific `System` class, but are useful additions to the simulators
+        It also constantly listens for custom commands that do not belong to a
+        specific `System` class, but are useful additions to the simulators
         framework."""
         self.socket = self.request
         if isinstance(self.socket, tuple):  # UDP client
@@ -138,7 +138,7 @@ class SendHandler(BaseHandler):
         """This method gets called right after the `setup` method ends its
         execution. It handles messages that the server has to periodically send
         to its connected client(s). It also constantly listens for custom
-        commands that does not belong to a specific `System` class, but are
+        commands that do not belong to a specific `System` class, but are
         useful additions to the simulators framework."""
         sampling_time = self.system.sampling_time
         message_queue = Queue(1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import time
 import socket
 import datetime
@@ -37,32 +38,32 @@ class TestListeningServer(unittest.TestCase):
         time.sleep(0.1)
 
     def test_proper_request(self):
-        response = get_response(self.address, msg='#command:a,b,c!')
+        response = get_response(self.address, msg='#command:a,b,c%')
         self.assertEqual(response, 'aabbcc')
 
     def test_wrong_request(self):
         """Wrong request but expected by the protocol"""
-        response = get_response(self.address, msg='#wrong_command:foo!')
+        response = get_response(self.address, msg='#wrong_command:foo%')
         self.assertRegexpMatches(response, 'you sent a wrong command')
 
     def test_value_error(self):
         """The message of ValueError in the logfile"""
-        get_response(self.address, msg='#valueerror:!', response=False)
+        get_response(self.address, msg='#valueerror:%', response=False)
         self.assertTrue('unexpected value' in get_logs())
 
     def test_unexpected_error(self):
-        get_response(self.address, msg='#unexpected:!', response=False)
+        get_response(self.address, msg='#unexpected:%', response=False)
         self.assertTrue('unexpected exception' in get_logs())
 
     def test_custom_command_with_parameters(self):
         response = get_response(
             self.address,
-            msg='$custom_command:a,b,c!'
+            msg='$custom_command:a,b,c%'
         )
         self.assertRegexpMatches(response, 'ok_abc')
 
     def test_custom_command_without_parameters(self):
-        response = get_response(self.address, msg='$custom_command!')
+        response = get_response(self.address, msg='$custom_command%')
         self.assertRegexpMatches(response, 'no_params')
 
 
@@ -87,37 +88,37 @@ class TestListeningUDPServer(unittest.TestCase):
         time.sleep(0.1)
 
     def test_proper_request(self):
-        response = get_response(self.address, msg='#command:a,b,c!', udp=True)
+        response = get_response(self.address, msg='#command:a,b,c%', udp=True)
         self.assertEqual(response, 'aabbcc')
 
     def test_wrong_request(self):
         """Wrong request but expected by the protocol"""
         response = get_response(
-            self.address, msg='#wrong_command:foo!', udp=True
+            self.address, msg='#wrong_command:foo%', udp=True
         )
         self.assertRegexpMatches(response, 'you sent a wrong command')
 
     def test_value_error(self):
         """The message of ValueError in the logfile"""
         get_response(
-            self.address, msg='#valueerror:!', response=False, udp=True
+            self.address, msg='#valueerror:%', response=False, udp=True
         )
         self.assertTrue('unexpected value' in get_logs())
 
     def test_unexpected_error(self):
         get_response(
-            self.address, msg='#unexpected:!', response=False, udp=True
+            self.address, msg='#unexpected:%', response=False, udp=True
         )
         self.assertTrue('unexpected exception' in get_logs())
 
     def test_custom_command_with_parameters(self):
         response = get_response(
-            self.address, msg='$custom_command:a,b,c!', udp=True
+            self.address, msg='$custom_command:a,b,c%', udp=True
         )
         self.assertRegexpMatches(response, 'ok_abc')
 
     def test_custom_command_without_parameters(self):
-        response = get_response(self.address, msg='$custom_command!', udp=True)
+        response = get_response(self.address, msg='$custom_command%', udp=True)
         self.assertRegexpMatches(response, 'no_params')
 
 
@@ -146,11 +147,11 @@ class TestSendingServer(unittest.TestCase):
         self.assertEqual(response, 'message')
 
     def test_unknown_command(self):
-        get_response(self.address, msg='$unknown!', response=False)
+        get_response(self.address, msg='$unknown%', response=False)
         self.assertTrue('command unknown not supported' in get_logs())
 
     def test_raise_exception(self):
-        get_response(self.address, msg='$raise_exception!', response=False)
+        get_response(self.address, msg='$raise_exception%', response=False)
         self.assertTrue(
             'unexpected exception raised by sendingtestsystem' in get_logs()
         )
@@ -181,12 +182,12 @@ class TestSendingUDPServer(unittest.TestCase):
         self.assertEqual(response, 'message')
 
     def test_unknown_command(self):
-        get_response(self.address, msg='$unknown!', response=False, udp=True)
+        get_response(self.address, msg='$unknown%', response=False, udp=True)
         self.assertTrue('command unknown not supported' in get_logs())
 
     def test_raise_exception(self):
         get_response(
-            self.address, msg='$raise_exception!', response=False, udp=True
+            self.address, msg='$raise_exception%', response=False, udp=True
         )
         self.assertTrue(
             'unexpected exception raised by sendingtestsystem' in get_logs()
@@ -216,23 +217,23 @@ class TestDuplexServer(unittest.TestCase):
         time.sleep(0.1)
 
     def test_proper_request(self):
-        response = get_response(self.l_address, msg='#command:a,b,c!')
+        response = get_response(self.l_address, msg='#command:a,b,c%')
         self.assertEqual(response, 'aabbcc')
 
     def test_wrong_request(self):
         """Wrong request but expected by the protocol"""
-        response = get_response(self.l_address, msg='#wrong_command:foo!')
+        response = get_response(self.l_address, msg='#wrong_command:foo%')
         self.assertRegexpMatches(response, 'you sent a wrong command')
 
     def test_custom_command_with_parameters(self):
         response = get_response(
             self.l_address,
-            msg='$custom_command:a,b,c!'
+            msg='$custom_command:a,b,c%'
         )
         self.assertRegexpMatches(response, 'ok_abc')
 
     def test_custom_command_without_parameters(self):
-        response = get_response(self.l_address, msg='$custom_command!')
+        response = get_response(self.l_address, msg='$custom_command%')
         self.assertRegexpMatches(response, 'no_params')
 
     def test_get_message(self):
@@ -240,7 +241,7 @@ class TestDuplexServer(unittest.TestCase):
         self.assertEqual(response, 'message')
 
     def test_last_cmd(self):
-        message = '#test:1,2,3!'
+        message = '#test:1,2,3%'
         l_response = get_response(self.l_address, msg=message)
         self.assertEqual(l_response, '112233')
         s_response = get_response(self.s_address)
@@ -271,28 +272,28 @@ class TestDuplexUDPServer(unittest.TestCase):
 
     def test_proper_request(self):
         response = get_response(
-            self.l_address, msg='#command:a,b,c!', udp=True
+            self.l_address, msg='#command:a,b,c%', udp=True
         )
         self.assertEqual(response, 'aabbcc')
 
     def test_wrong_request(self):
         """Wrong request but expected by the protocol"""
         response = get_response(
-            self.l_address, msg='#wrong_command:foo!', udp=True
+            self.l_address, msg='#wrong_command:foo%', udp=True
         )
         self.assertRegexpMatches(response, 'you sent a wrong command')
 
     def test_custom_command_with_parameters(self):
         response = get_response(
             self.l_address,
-            msg='$custom_command:a,b,c!',
+            msg='$custom_command:a,b,c%',
             udp=True
         )
         self.assertRegexpMatches(response, 'ok_abc')
 
     def test_custom_command_without_parameters(self):
         response = get_response(
-            self.l_address, msg='$custom_command!', udp=True
+            self.l_address, msg='$custom_command%', udp=True
         )
         self.assertRegexpMatches(response, 'no_params')
 
@@ -301,7 +302,7 @@ class TestDuplexUDPServer(unittest.TestCase):
         self.assertEqual(response, 'message')
 
     def test_last_cmd(self):
-        message = '#test:1,2,3!'
+        message = '#test:1,2,3%'
         l_response = get_response(self.l_address, msg=message, udp=True)
         self.assertEqual(l_response, '112233')
         s_response = get_response(self.s_address, udp=True)
@@ -342,7 +343,7 @@ class TestSimulator(unittest.TestCase):
 
         self.simulator.start(daemon=True)
 
-        response = get_response(address, msg='#command:a,b,c!')
+        response = get_response(address, msg='#command:a,b,c%')
         self.assertEqual(response, 'aabbcc')
 
         self.simulator.stop()
@@ -367,7 +368,7 @@ class TestSimulator(unittest.TestCase):
 
         self.simulator.start(daemon=True)
 
-        l_response = get_response(l_addr, msg='#command:a,b,c!')
+        l_response = get_response(l_addr, msg='#command:a,b,c%')
         self.assertEqual(l_response, 'aabbcc')
         s_response = get_response(s_addr)
         self.assertEqual(s_response, 'command:a,b,c')
@@ -391,10 +392,10 @@ class TestSimulator(unittest.TestCase):
         t = Thread(target=simulator.start)
         t.start()
         time.sleep(0.1)
-        response = get_response(l_addr, msg='$system_stop!')
-        self.assertEqual(response, '$server_shutdown!')
-        response = get_response(s_addr, msg='$system_stop!')
-        self.assertEqual(response, '$server_shutdown!')
+        response = get_response(l_addr, msg='$system_stop%')
+        self.assertEqual(response, '$server_shutdown%')
+        response = get_response(s_addr, msg='$system_stop%')
+        self.assertEqual(response, '$server_shutdown%')
         t.join()
 
 
@@ -412,8 +413,8 @@ class TestServerVarious(unittest.TestCase):
 
         def shutdown(self):
             time.sleep(0.01)
-            response = get_response(address, msg='$system_stop!')
-            self.assertEqual(response, '$server_shutdown!')
+            response = get_response(address, msg='$system_stop%')
+            self.assertEqual(response, '$server_shutdown%')
 
         t = Thread(target=shutdown, args=(self,))
         t.start()
@@ -461,7 +462,8 @@ def get_logs():
     time.sleep(0.03)
     now = datetime.datetime.now()
     logs = []
-    for line in open('sim-server.log', 'r').readlines():
+    filename = os.path.join(os.getenv('ACSDATA', ''), 'sim-server.log')
+    for line in open(filename, 'r').readlines():
         line = line.strip()
         log_date = datetime.datetime.strptime(
             ' '.join(line.split(' ')[0:2]) + '000',
@@ -476,7 +478,7 @@ def get_logs():
 class ListeningTestSystem(ListeningSystem):
 
     header = b'#'
-    tail = b'!'
+    tail = b'%'
 
     def __init__(self):
         self.msg = b''
@@ -520,7 +522,7 @@ class ListeningTestSystem(ListeningSystem):
 
 class SendingTestSystem(SendingSystem):
 
-    sampling_time = 0.01
+    #sampling_time = 0.01
 
     def __init__(self):
         try:


### PR DESCRIPTION
Issue #208, replaced ending character for custom commands in order to avoid clashes with the starting character of the minor servos protocol

Issue #209, now the `test_server.py` test file accounts for the presence of the `ACSDATA` environment variable and points to the correct path for some tests

Also, documentation for `common.py` and `server.py` has been improved.