### PR TITLE
Fix #217, fix #218, see changelog below.

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -205,4 +205,6 @@ The Utils library
 
 .. autofunction:: day_percentage
 
-.. autofunction:: get_systems
+.. autofunction:: get_multitype_systems
+
+.. autofunction:: list_simulators

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -323,27 +323,29 @@ defined as follows::
 
     class MultiTypeSystem(object):
 
-        def __new__(self, *args):
+        def __new__(self, **kwargs):
             if cls.system_type not in cls.systems:
                 raise ValueError(...)
 
-            return cls.systems[cls.system_type].System(*args)
+            return cls.systems[cls.system_type].System(**kwargs)
 
 The inherited ``System`` classes must override the ``__new__`` method as
 follows::
 
     class System(MultiTypeSystem):
 
-        def __new__(cls, *args):
+        def __new__(cls, **kwargs):
             cls.system = systems
-            cls.system_type = system_type
-            return MultiTypeSystem.__new__(cls, *args)
+            cls.system_type = kwargs.pop('system_type')
+            return MultiTypeSystem.__new__(cls, **kwargs)
 
 where ``systems`` is the list of available systems for that particular module
-(that can automatically be retrieved calling the ``utils.get_systems()``
-function) and ``system_type`` is the variable storing the desired system type
-name, this is the variable to override in order to ask for a different system
-type. If you want to see additional informations about inheriting the
+(that can be retrieved calling the ``utils.get_multitype_systems(__file__)``
+function) and ``system_type`` is the keyworded argument that indicates the
+desired system type name. In order to instantiate a system of this kind, it is
+mandatory to pass the ``system_type`` argument as a keyworded argument. If the
+given ``system_type`` argument refers to an unknown system type, an exception
+is raised. If you want to see additional informations about inheriting the
 ``MultiTypeSystem`` class take a look at the
 :download:`if_distributor <../simulators/if_distributor/__init__.py>` module.
 

--- a/scripts/discos-simulator
+++ b/scripts/discos-simulator
@@ -5,10 +5,16 @@
   $ discos-simulator start -s if_distributor
   $ discos-simulator stop -s if_distributor
 """
+from __future__ import print_function
 import importlib
+import subprocess
+import sys
 from argparse import ArgumentParser, ArgumentTypeError
 
 from simulators.server import Simulator
+from simulators.utils import list_simulators
+
+AVAILABLE_SIMULATORS = list_simulators()
 
 
 def system_from_arg(system_name):
@@ -24,41 +30,78 @@ def system_from_arg(system_name):
 
 parser = ArgumentParser()
 parser.add_argument(
+    'action',
+    choices=['start', 'stop', 'list']
+)
+parser.add_argument(
     '-s', '--system',
     type=system_from_arg,
-    required=True,
+    required=False,
     help='System name: active_surface, acu, ...',
 )
 parser.add_argument(
     '-t', '--type',
+    type=str,
     required=False,
     help='System configuration type: IFD_14_channels for if_distributor, ...',
 )
-parser.add_argument(
-    'action',
-    choices=['start', 'stop']
-)
-
 args = parser.parse_args()
+
+if args.action == 'list':
+    print(
+        "Available simulators: '"
+        + "', '".join(AVAILABLE_SIMULATORS)
+        + "'."
+    )
+
+kwargs = {}
 
 if args.type:
     try:
         systems = getattr(args.system, 'systems')
     except AttributeError:
-        raise ArgumentTypeError(
+        parser.error(
             ('System %s has no configurations other than the default one. '
             % args.system.__name__.rsplit('.', 1)[1])
             + "Omit the '--type' flag to start the simulator properly."
         )
     if args.type not in systems:
-        raise ArgumentTypeError(
+        parser.error(
             'Configuration %s for system %s not found.'
             % (args.type, args.system.__name__.rsplit('.', 1)[1])
         )
-    args.system.system_type = args.type
+    kwargs['system_type'] = args.type
 
-simulator = Simulator(args.system)
 if args.action == 'start':
-    simulator.start()
+    if args.system:
+        simulator = Simulator(args.system, **kwargs)
+        simulator.start()
+    else:
+        for sim in AVAILABLE_SIMULATORS:
+            subprocess.Popen([
+                sys.argv[0],
+                'start',
+                '-s',
+                sim
+            ])
 elif args.action == 'stop':
-    simulator.stop()
+    if args.system:
+        simulator = Simulator(args.system, **kwargs)
+        simulator.stop()
+    else:
+        for sim in AVAILABLE_SIMULATORS:
+            sim = importlib.import_module('simulators.%s' % sim)
+            simulator = Simulator(sim, **kwargs)
+            simulator.stop()
+        #ps = subprocess.Popen(
+        #    ['ps', 'aux'],
+        #    stdout=subprocess.PIPE
+        #).communicate()[0]
+        #processes = {}
+        #for proc in ps.split('\n'):
+        #    args = proc.split()
+        #    if not args:
+        #        continue
+        #    command = ' '.join(args[10:])
+        #    if '%s start -s %s' % (sys.argv[0], sim) in command:
+        #        os.kill(int(args[1]), signal.SIGINT)

--- a/scripts/discos-simulator
+++ b/scripts/discos-simulator
@@ -57,13 +57,18 @@ if args.action == 'list':
 kwargs = {}
 
 if args.type:
+    if not args.system:
+        parser.error(
+            "The '--type' argument only has to be used "
+            + "in conjunction with the '--system' argument."
+        )
     try:
         systems = getattr(args.system, 'systems')
     except AttributeError:
         parser.error(
             ('System %s has no configurations other than the default one. '
             % args.system.__name__.rsplit('.', 1)[1])
-            + "Omit the '--type' flag to start the simulator properly."
+            + "Omit the '--type' argument to start the simulator properly."
         )
     if args.type not in systems:
         parser.error(

--- a/simulators/active_surface/__init__.py
+++ b/simulators/active_surface/__init__.py
@@ -7,16 +7,16 @@ from simulators import utils
 from simulators.common import ListeningSystem
 from simulators.active_surface.usd import USD
 
-# Each system module (like active_surface.py, acu.py, etc.) has to
-# define a list called servers.s This list contains tuples
-# (l_address, s_address, args). l_address is the tuple (ip, port) that
-# defines the listening node that exposes the parse method, s_address
-# is the tuple that defines the optional sending node that exposes the
-# get_message method, while args is a tuple of optional extra arguments.
+
 servers = []
 for line in range(96):  # 96 servers
     l_address = ('0.0.0.0', 11000 + line)
-    servers.append((l_address, (), ThreadingTCPServer, (1, 17)))
+    servers.append((
+        l_address,
+        (),
+        ThreadingTCPServer,
+        {'min_usd_index': 1, 'max_usd_index': 17}
+    ))
 
 
 class System(ListeningSystem):

--- a/simulators/acu/__init__.py
+++ b/simulators/acu/__init__.py
@@ -13,15 +13,9 @@ from simulators.acu.pointing_status import PointingStatus
 from simulators.acu.facility_status import FacilityStatus
 
 
-# Each system module (like active_surface.py, acu.py, etc.) has to
-# define a list called servers.s This list contains tuples
-# (l_address, s_address, args). l_address is the tuple (ip, port) that
-# defines the listening node that exposes the parse method, s_address
-# is the tuple that defines the optional sending node that exposes the
-# get_message method, while args is a tuple of optional extra arguments.
 servers = []
 servers.append(
-    (('0.0.0.0', 13000), ('0.0.0.0', 13001), ThreadingTCPServer, ())
+    (('0.0.0.0', 13000), ('0.0.0.0', 13001), ThreadingTCPServer, {})
 )
 
 start_flag = b'\x1A\xCF\xFC\x1D'

--- a/simulators/backend/__init__.py
+++ b/simulators/backend/__init__.py
@@ -5,7 +5,7 @@ from simulators.backend.genericbackend import GenericBackend, BackendException
 from simulators.utils import ACS_TO_UNIX_TIME
 
 
-servers = [(('0.0.0.0', 12800), (), ThreadingTCPServer, ())]
+servers = [(('0.0.0.0', 12800), (), ThreadingTCPServer, {})]
 
 PROTOCOL_VERSION = '1.2'
 headers = ('!', '?')

--- a/simulators/calmux/__init__.py
+++ b/simulators/calmux/__init__.py
@@ -5,12 +5,12 @@ from simulators.common import ListeningSystem
 
 # Each system module (like active_surface.py, acu.py, etc.) has to
 # define a list called servers. This list contains tuples
-# (l_address, s_address, args). l_address is the tuple (ip, port) that
+# (l_address, s_address, kwargs). l_address is the tuple (ip, port) that
 # defines the listening node that exposes the parse method, s_address
 # is the tuple that defines the optional sending node that exposes the
-# subscribe and unsibscribe methods, while args is a tuple of optional
+# subscribe and unsibscribe methods, while kwargs is a dict of optional
 # extra arguments.
-servers = [(('0.0.0.0', 12500), (), ThreadingTCPServer, ())]
+servers = [(('0.0.0.0', 12500), (), ThreadingTCPServer, {})]
 
 
 class System(ListeningSystem):

--- a/simulators/common.py
+++ b/simulators/common.py
@@ -81,7 +81,7 @@ class SendingSystem(BaseSystem):
 
 class MultiTypeSystem(object):
 
-    def __new__(cls, *args):
+    def __new__(cls, **kwargs):
         """This class acts as a 'class factory', it means that given the
         attributes `system_type` and `systems` (that must be set in inherited
         classes), creating an instance of `MultiTypeSystem` (or some other
@@ -95,4 +95,4 @@ class MultiTypeSystem(object):
         if cls.system_type not in cls.systems:
             raise ValueError('System type %s not found.' % cls.system_type)
 
-        return cls.systems[cls.system_type].System(*args)
+        return cls.systems[cls.system_type].System(**kwargs)

--- a/simulators/if_distributor/__init__.py
+++ b/simulators/if_distributor/__init__.py
@@ -1,23 +1,17 @@
 from SocketServer import ThreadingTCPServer
-from simulators import utils
+from simulators.utils import get_multitype_systems
 from simulators.common import MultiTypeSystem
 
-# Each system module (like active_surface.py, acu.py, etc.) has to
-# define a list called servers.s This list contains tuples
-# (l_address, s_address, args). l_address is the tuple (ip, port) that
-# defines the listening node that exposes the parse method, s_address
-# is the tuple that defines the optional sending node that exposes the
-# get_message method, while args is a tuple of optional extra arguments.
-servers = [(('0.0.0.0', 12000), (), ThreadingTCPServer, ())]
 
-systems = utils.get_systems()
-default_system_type = 'IFD'
-system_type = default_system_type
+systems = get_multitype_systems(__file__)
+servers = [
+    (('0.0.0.0', 12000), (), ThreadingTCPServer, {'system_type': 'IFD'})
+]
 
 
 class System(MultiTypeSystem):
 
-    def __new__(cls, *args):
+    def __new__(cls, **kwargs):
         cls.systems = systems
-        cls.system_type = system_type
-        return MultiTypeSystem.__new__(cls, *args)
+        cls.system_type = kwargs.pop('system_type')
+        return MultiTypeSystem.__new__(cls, **kwargs)

--- a/simulators/lo/__init__.py
+++ b/simulators/lo/__init__.py
@@ -4,9 +4,9 @@ from SocketServer import ThreadingTCPServer
 from simulators.common import ListeningSystem
 
 servers = [
-    (('0.0.0.0', 12700), (), ThreadingTCPServer, ()),
-    (('0.0.0.0', 12701), (), ThreadingTCPServer, ()),
-    (('0.0.0.0', 12702), (), ThreadingTCPServer, ()),
+    (('0.0.0.0', 12700), (), ThreadingTCPServer, {}),
+    (('0.0.0.0', 12701), (), ThreadingTCPServer, {}),
+    (('0.0.0.0', 12702), (), ThreadingTCPServer, {}),
 ]
 
 

--- a/simulators/mscu/__init__.py
+++ b/simulators/mscu/__init__.py
@@ -7,7 +7,7 @@ from simulators.common import ListeningSystem
 from simulators.mscu.servo import Servo
 from simulators.mscu.parameters import headers, closers, app_nr
 
-servers = [(('0.0.0.0', 10000), (), ThreadingTCPServer, ())]
+servers = [(('0.0.0.0', 10000), (), ThreadingTCPServer, {})]
 
 
 class System(ListeningSystem):

--- a/simulators/weather_station/__init__.py
+++ b/simulators/weather_station/__init__.py
@@ -4,14 +4,7 @@ from threading import current_thread
 from simulators.common import ListeningSystem
 
 
-# Each system module (like active_surface.py, acu.py, etc.) has to
-# define a list called servers. This list contains tuples
-# (l_address, s_address, args). l_address is the tuple (ip, port) that
-# defines the listening node that exposes the parse method, s_address
-# is the tuple that defines the optional sending node that exposes the
-# subscribe and unsibscribe methods, while args is a tuple of optional
-# extra arguments.
-servers = [(('0.0.0.0', 12600), (), ThreadingUDPServer, ())]
+servers = [(('0.0.0.0', 12600), (), ThreadingUDPServer, {})]
 
 
 class System(ListeningSystem):

--- a/tests/test_if_distributor.py
+++ b/tests/test_if_distributor.py
@@ -1,15 +1,11 @@
 import unittest
-from simulators import if_distributor
+from simulators.if_distributor import System
 
 
 class TestIFDistributorDefaultConfiguration(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        reload(if_distributor)
-
     def setUp(self):
-        self.system = if_distributor.System()
+        self.system = System(system_type='IFD')
 
     def _send(self, message):
         for byte in message[:-1]:
@@ -192,13 +188,8 @@ class TestIFDistributorDefaultConfiguration(unittest.TestCase):
 
 class TestIFDistributor14Channels(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        reload(if_distributor)
-        if_distributor.system_type = 'IFD_14_channels'
-
     def setUp(self):
-        self.system = if_distributor.System()
+        self.system = System(system_type='IFD_14_channels')
 
     def test_get_header(self):
         """Return True when the first byte is the header."""
@@ -404,14 +395,9 @@ class TestIFDistributor14Channels(unittest.TestCase):
 
 class TestIFDistributorUnknownType(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        reload(if_distributor)
-        if_distributor.system_type = 'unknown'
-
     def test_unknown_type(self):
         with self.assertRaises(ValueError):
-            self.system = if_distributor.System()
+            self.system = System(system_type='unknown')
 
 
 if __name__ == '__main__':

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ class TestListeningServer(unittest.TestCase):
         cls.server = Server(
             ListeningTestSystem,
             ThreadingTCPServer,
-            args=(),
+            kwargs={},
             l_address=cls.address
         )
         cls.server.start()
@@ -114,7 +114,7 @@ class TestListeningUDPServer(unittest.TestCase):
         cls.server = Server(
             ListeningTestSystem,
             ThreadingUDPServer,
-            args=(),
+            kwargs={},
             l_address=cls.address
         )
         cls.server.start()
@@ -169,7 +169,7 @@ class TestSendingServer(unittest.TestCase):
         cls.server = Server(
             SendingTestSystem,
             ThreadingTCPServer,
-            args=(),
+            kwargs={},
             s_address=cls.address
         )
         cls.server.start()
@@ -204,7 +204,7 @@ class TestSendingUDPServer(unittest.TestCase):
         cls.server = Server(
             SendingTestSystem,
             ThreadingUDPServer,
-            args=(),
+            kwargs={},
             s_address=cls.address
         )
         cls.server.start()
@@ -242,7 +242,7 @@ class TestDuplexServer(unittest.TestCase):
         cls.server = Server(
             DuplexTestSystem,
             ThreadingTCPServer,
-            args=(),
+            kwargs={},
             l_address=cls.l_address,
             s_address=cls.s_address
         )
@@ -313,7 +313,7 @@ class TestDuplexUDPServer(unittest.TestCase):
         cls.server = Server(
             DuplexTestSystem,
             ThreadingUDPServer,
-            args=(),
+            kwargs={},
             l_address=cls.l_address,
             s_address=cls.s_address
         )
@@ -376,7 +376,7 @@ class TestSimulator(unittest.TestCase):
 
     def test_create_simulator_from_module(self):
         address = ('127.0.0.1', 10004)
-        self.mymodule.servers = [(address, (), ThreadingTCPServer, ())]
+        self.mymodule.servers = [(address, (), ThreadingTCPServer, {})]
         self.mymodule.System = ListeningTestSystem
 
         simulator = Simulator(self.mymodule)
@@ -385,7 +385,7 @@ class TestSimulator(unittest.TestCase):
 
     def test_create_simulator_from_name(self):
         address = ('127.0.0.1', 10005)
-        self.mymodule.servers = [(address, (), ThreadingTCPServer, ())]
+        self.mymodule.servers = [(address, (), ThreadingTCPServer, {})]
         self.mymodule.System = ListeningTestSystem
 
         simulator = Simulator('mymodule')
@@ -394,7 +394,7 @@ class TestSimulator(unittest.TestCase):
 
     def test_start_and_stop_listening(self):
         address = ('127.0.0.1', 10006)
-        self.mymodule.servers = [(address, (), ThreadingTCPServer, ())]
+        self.mymodule.servers = [(address, (), ThreadingTCPServer, {})]
         self.mymodule.System = ListeningTestSystem
 
         self.simulator.start(daemon=True)
@@ -410,7 +410,7 @@ class TestSimulator(unittest.TestCase):
 
     def test_start_and_stop_sending(self):
         address = ('127.0.0.1', 10007)
-        self.mymodule.servers = [((), address, ThreadingTCPServer, ())]
+        self.mymodule.servers = [((), address, ThreadingTCPServer, {})]
         self.mymodule.System = SendingTestSystem
 
         self.simulator.start(daemon=True)
@@ -423,7 +423,7 @@ class TestSimulator(unittest.TestCase):
     def test_start_and_stop_duplex(self):
         l_addr = ('127.0.0.1', 10008)
         s_addr = ('127.0.0.1', 10009)
-        self.mymodule.servers = [(l_addr, s_addr, ThreadingTCPServer, ())]
+        self.mymodule.servers = [(l_addr, s_addr, ThreadingTCPServer, {})]
         self.mymodule.System = DuplexTestSystem
 
         self.simulator.start(daemon=True)
@@ -441,14 +441,14 @@ class TestSimulator(unittest.TestCase):
 
     def test_stop_without_start(self):
         address = ('127.0.0.1', 10007)
-        self.mymodule.servers = [((), address, ())]
+        self.mymodule.servers = [((), address, {})]
         self.mymodule.System = SendingTestSystem
         self.simulator.stop()
 
     def test_non_daemon_simulator(self):
         l_addr = ('127.0.0.1', 10010)
         s_addr = ('127.0.0.1', 10011)
-        self.mymodule.servers = [(l_addr, s_addr, ThreadingTCPServer, ())]
+        self.mymodule.servers = [(l_addr, s_addr, ThreadingTCPServer, {})]
         self.mymodule.System = DuplexTestSystem
 
         simulator = Simulator(self.mymodule)
@@ -474,7 +474,7 @@ class TestServerVarious(unittest.TestCase):
         server = Server(
             ListeningTestSystem,
             ThreadingTCPServer,
-            args=(),
+            kwargs={},
             l_address=address,
         )
         server.start()
@@ -497,7 +497,7 @@ class TestServerVarious(unittest.TestCase):
             Server(
                 ListeningTestSystem,
                 ThreadingTCPServer,
-                args=()
+                kwargs={}
             )
 
     def test_server_wrong_socket_type(self):
@@ -506,7 +506,7 @@ class TestServerVarious(unittest.TestCase):
             Server(
                 ListeningTestSystem,
                 object,
-                args=(),
+                kwargs={},
                 l_address=address
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -345,6 +345,10 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(ValueError):
             utils.day_percentage('dummy')
 
+    def test_list_simulators(self):
+        simulators = utils.list_simulators()
+        self.assertIsInstance(simulators, list)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #217, now the `discos-simulator` command is able to start all the
simulators instead of a single one per command. In order to do so, you
just have to issue the following command:
`discos-simulator start`.
Fix #218, in order to enable #217, a list of all simulators implemented
in the package had to be defined or automatically retrieved as a
function. The latter was the chosen approach, a `list_simulator`
function was implemented inside the `utils` library.

This commit brings also some major improvements regarding the
`MultiTypeSystem` class. The way the desired system gets chosen for this
kind of simulator is now cleaner and definitely more pythonic (the
desired system type is now chosen as a keyworded argument).