### PR TITLE
Fix #224, set a fixed version of prospector (1.2.0)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = /bin/bash -c "python -m doctest simulators/*.py"
 [testenv:linter]
 deps =
     -rrequirements.txt
-    prospector
+    prospector==1.2.0
 skip_install = true
 commands = prospector
 


### PR DESCRIPTION
The 1.2.0 version is the last version compatible with python 2.7