### PR TITLE
Fix #238, fixed the ACU simulator issue that caused disconnection

### DIFF
--- a/simulators/acu/axis_status.py
+++ b/simulators/acu/axis_status.py
@@ -1746,7 +1746,7 @@ class MasterAxisStatus(SimpleAxisStatus):
             if next_pos and self.axis_state == 3 and not self.stowed:
 
                 if self.ptState == 2:
-                    self.p_Soll = self.next_pos + self.p_Offset
+                    self.p_Soll = next_pos + self.p_Offset
                     self.v_Soll = int(round(rate * 1000000))
 
                     if p_Ist != self.p_Soll:


### PR DESCRIPTION
The disconnection was caused by some multi threading unhandled concurrency. It caused some issues with some lists and sometimes lead to accessing an empty list and therefore crashing. Fixed by correcting the logic behind the behavior and by adding some multi threading synchronization variables.