### PR TITLE
Fix #312, removed hardcoded ports from tests

### DIFF
--- a/simulators/server.py
+++ b/simulators/server.py
@@ -17,7 +17,7 @@ from .common import BaseSystem
 
 logging.basicConfig(
     filename=os.path.join(os.getenv('ACSDATA', ''), 'sim-server.log'),
-    format='%(asctime)s %(message)s',
+    format='%(asctime)s %(process)d %(message)s',
     level=logging.DEBUG)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -617,7 +617,7 @@ def get_logs():
         f.seek(0, os.SEEK_END)
         # read last 3 lines with current process ID
         buffer_string = ''
-        while len(logs) < 3:
+        while len(logs) <= 3:
             try:
                 f.seek(-2, os.SEEK_CUR)
                 buffer_string += f.read(1).decode('utf-8')


### PR DESCRIPTION
Hardcoded ports were removed from test_server.py and they were replaced with a python generator that checks if a given port is available, then use that port for the next test. This allows multiple instances of the same test file to be executed concurrently without clashing issues. In order to enable this feature a minor fix was introduced regarding the logging style, now the logger also prints to file the PID of the process logging some information. The PID is then used when testing and reading from the default logfile in order for each test process to read only its lines without issues.