### PR TITLE
Fix #326, fixed the memory leak for programTrack

### DIFF
--- a/simulators/minor_servos/__init__.py
+++ b/simulators/minor_servos/__init__.py
@@ -264,7 +264,7 @@ class System(ListeningSystem):
                 steps += 5
 
                 t = start_time
-                for step in range(steps):
+                for _ in range(steps):
                     t -= self.program_track_timegap
                     servo.trajectory[0].append(t)
                 servo.trajectory[0].reverse()

--- a/simulators/minor_servos/__init__.py
+++ b/simulators/minor_servos/__init__.py
@@ -13,6 +13,7 @@ except ImportError as ex:  # pragma: no cover
         + ' to run, is missing!') from ex
 from threading import Lock
 from bisect import bisect_left
+from math import ceil
 from socketserver import ThreadingTCPServer
 from simulators.common import ListeningSystem
 
@@ -251,10 +252,19 @@ class System(ListeningSystem):
                 servo.trajectory_id = trajectory_id
                 servo.trajectory_start_time = start_time
 
-                # Backtrace trajectory to now
+                # Backtrace trajectory to current position
+                steps = 0
+                for index in range(servo.DOF):
+                    delta = abs(coords[index] - servo.coords[index])
+                    steps = max(
+                        steps,
+                        ceil(delta / servo.max_delta[index] / 5)
+                    )
+                # Add 1 second
+                steps += 5
+
                 t = start_time
-                now = time.time()
-                while t > now:
+                for step in range(steps):
                     t -= self.program_track_timegap
                     servo.trajectory[0].append(t)
                 servo.trajectory[0].reverse()

--- a/tests/test_minor_servos.py
+++ b/tests/test_minor_servos.py
@@ -359,6 +359,19 @@ class TestMinorServos(unittest.TestCase):
                 self.assertTrue(self.system.parse(byte))
             self.assertRegex(self.system.parse(cmd[-1]), bad)
 
+    def test_program_track_start_way_in_the_future(self):
+        start_time = time.time() * 1000000
+        for servo_id, servo in self.system.servos.items():
+            coords = [random.uniform(0, 100) for _ in range(servo.DOF)]
+            cmd = f'PROGRAMTRACK={servo_id},0,0,{start_time:.6f},'
+            cmd += f'{",".join(map(str, coords))}{tail}'
+            for byte in cmd[:-1]:
+                self.assertTrue(self.system.parse(byte))
+            if servo.program_track_capable:
+                self.assertRegex(self.system.parse(cmd[-1]), f'{good}{tail}$')
+            else:
+                self.assertRegex(self.system.parse(cmd[-1]), bad)
+
     def test_program_track_append_with_start(self):
         self.test_program_track()
         for servo_id, servo in self.system.servos.items():


### PR DESCRIPTION
Instead of building back a trajectory to the current time, the trajectory only backtrace to the current axes position and 1 more second in the past. This avoids memory leaks when a `start_time` way further in the future is sent with the first programTrack command.