### PR TITLE
Fix #332, fixed readthedocs version to 3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,6 @@ sphinx:
 
 # Explicitly set the version of Python and its requirements
 python:
-  version: 3.9
+  version: 3
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
Python version 3.9 does not work in readthedocs, the build process fails with the following error:
`Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.9`.
For now I set the version to 3 hoping it will start succeeding in building again. If it doesn't we should change it to 3.8 hoping we don't have any 3.9 specific code that can make the doc building process fail.